### PR TITLE
Ignore secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ main.js.map
 
 .idea
 npm-debug.log.*
+
+# SHHHHHH
+app/utils/github.settings.js


### PR DESCRIPTION
just edits .gitignore now so we don't upload auth secrets later unlike a certain similar capstone project..